### PR TITLE
Add Codecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,10 @@
     
 ### :hammer_and_wrench: Tools
 
+- [Codecks](https://github.com/vaddisrinivas/codecks)
+
+    - Local-first Android command deck, Bluetooth trackpad, and reviewable Mac automation surface.
+
 - [GitFox](https://gitlab.com/terrakok/gitlab-client)
 
     - Client to manage GitLab projects. Clean Architecture implementation


### PR DESCRIPTION
Adds Codecks under Tools.\n\nCodecks is an Apache-2.0 Android app for local-first Mac command decks, Bluetooth trackpad control, and reviewable automations.