### PR TITLE
Add AI Dictation to Productivity

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ Here's a list of open-source contributors who have compiled the resources:
 - [Tunde-Sanusi](https://github.com/tuhamworld)
 - [sharshv2012](https://github.com/sharshv2012)
 - [yogeshpaliyal](https://github.com/yogeshpaliyal)
+- [vood](https://github.com/vood)

--- a/README.md
+++ b/README.md
@@ -610,6 +610,10 @@
 
     
 ### :rocket: Productivity     
+- [AI Dictation](https://github.com/writingmate/aidictation)
+
+    - Open-source speech-to-text app with a Kotlin Android client, offline recognition on supported devices, and optional cloud transcription and cleanup.
+
 - [OSSAVE](https://github.com/mukuldeep/OSSAVE)
 
     - Open Source Simple Android Video Editor


### PR DESCRIPTION
## What changed

Adds AI Dictation to the Productivity section and adds the contributor entry required by the contribution guide.

## Why it fits

AI Dictation is a usable open-source Android speech-to-text app. Its Kotlin client lives in the public repository under the MIT License, the current Google Play listing is live, and a tagged Android release includes an APK and checksums. The entry keeps the offline claim conditional and explicitly describes cloud transcription and cleanup as optional.

## Checks

- Searched the README, issues, and pull requests for duplicates
- Verified the current Google Play listing and Android release
- Verified the canonical repository and MIT license
- Confirmed the Android client uses Kotlin and Jetpack Compose Material 3
- Ran `git diff --check`
- Limited the change to the app entry and required contributor line

## Disclosure

I am affiliated with AI Dictation and am submitting the project openly rather than presenting it as an independent recommendation. This contribution was prepared with AI assistance and manually checked against the current source, store listing, release evidence, and contribution guide.