### PR TITLE
Add Git Store to Android open-source tools

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ Here's a list of open-source contributors who have compiled the resources:
 - [Tunde-Sanusi](https://github.com/tuhamworld)
 - [sharshv2012](https://github.com/sharshv2012)
 - [yogeshpaliyal](https://github.com/yogeshpaliyal)
+- [Darkmintis](https://github.com/Darkmintis)

--- a/README.md
+++ b/README.md
@@ -701,6 +701,10 @@
 
     - Client to manage GitLab projects. Clean Architecture implementation
 
+- [Git Store](https://github.com/Darkmintis/Git-Store)
+
+    - An Android-first open-source app store for discovering and installing APKs published through GitHub Releases.
+
 - [Google Science Journal](https://github.com/google/science-journal)
 
     - Use the sensors in your mobile devices to perform science experiments.


### PR DESCRIPTION
Adds [Git Store](https://github.com/Darkmintis/Git-Store) to the Tools category.

[Git Store](https://github.com/Darkmintis/Git-Store) is a modern Android client for finding and installing open-source apps straight from GitHub releases. Instead of hunting through repos by hand, you get a proper store experience: trending Android projects, one-tap APK install, and update alerts for the apps you already have.

**What it does**
- Discovers trending and popular GitHub repos that actually ship Android releases
- Installs APKs in one tap, directly from the latest release
- Tracks installed apps and notifies you when a new version is out
- Search and filter by language and category
- Full repo pages with releases, changelogs, and project details
- Star and save favorites, with GitHub OAuth for a personalized feed

Apache 2.0, source and APKs on GitHub: https://github.com/Darkmintis/Git-Store